### PR TITLE
Manually revert 8bf3308

### DIFF
--- a/release.properties
+++ b/release.properties
@@ -4,7 +4,7 @@
 # these are the numbers for the NEXT release from this branch
 release.major=4
 release.minor=1
-release.build=2
+release.build=3
 
 # set this to true if this tree has been branched from the trunk
 release.is_branched=true


### PR DESCRIPTION
Manually revert 8bf3308 by editing the one file changed in that commit. You really do not want to merge an older release branch back into master under any circumstances.

This is being done manually because other changes that should be retained were done afterwards.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/sonnyshansen/jmri/1)
<!-- Reviewable:end -->
